### PR TITLE
chore: Add OCI credentials to registry auth for use by helm

### DIFF
--- a/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
+++ b/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
@@ -233,8 +233,7 @@ spec:
     - name: .dockerconfigjson
       question: Docker JSON Configuration
       noMask: true
-      help: This is the docker JSON configuration for authenticating with container
-        registries
+      help: This is the docker JSON configuration for authenticating with container registries
       template: |-
         {
         {{- if eq .Requirements.cluster.provider "gke" }}
@@ -286,8 +285,14 @@ spec:
               {{- end }}
                 "auth": {{ auth "jx-git-operator.jx-boot" "username" "password" | b64enc | quote}}
             }
+          {{- if and .Requirements.cluster.chartRepository (secret "jx-boot-job-env-vars" "JX_REPOSITORY_USERNAME") (eq .Requirements.cluster.chartKind "oci") }}
+             ,
+             {{- $chartRepo := .Requirements.cluster.chartRepository }}
+             {{- $chartHost := (splitList "/" $chartRepo)._0 }}
+             "{{ $chartHost }}": {
+               "auth": {{ printf "%s:%s" (secret "jx-boot-job-env-vars" "JX_REPOSITORY_USERNAME") (secret "jx-boot-job-env-vars" "JX_REPOSITORY_PASSWORD") | b64enc | quote }}
+             }
+          {{- end }}
           {{- end }}
           }
         }
-
-


### PR DESCRIPTION
## Changes

* Add OCI registry authentication to Docker configuration secret schema
* Include JX_REPOSITORY_USERNAME and JX_REPOSITORY_PASSWORD credentials in .dockerconfigjson when using OCI chart repositories


## Context

Helm CLI does not use `credHelpers` within docker config for authentication (https://github.com/helm/helm/issues/13228) but _does_ support `auth`, with an encoded username and password.

when `chartKind: true`, let's use `JX_REPOSITORY_USERNAME` and `JX_REPOSITORY_PASSWORD` from the `jx-boot-job-env-vars` secret to generate an auth entry so helm can authenticate.