### PR TITLE
fix: use namespace when getting ACR OCI username and password

### DIFF
--- a/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
+++ b/charts/jxgh/jxboot-helmfile-resources/secret-schema.yaml
@@ -285,12 +285,12 @@ spec:
               {{- end }}
                 "auth": {{ auth "jx-git-operator.jx-boot" "username" "password" | b64enc | quote}}
             }
-          {{- if and .Requirements.cluster.chartRepository (secret "jx-boot-job-env-vars" "JX_REPOSITORY_USERNAME") (eq .Requirements.cluster.chartKind "oci") }}
+          {{- if and .Requirements.cluster.chartRepository (secret "jx-git-operator.jx-boot-job-env-vars" "JX_REPOSITORY_USERNAME") (eq .Requirements.cluster.chartKind "oci") }}
              ,
              {{- $chartRepo := .Requirements.cluster.chartRepository }}
              {{- $chartHost := (splitList "/" $chartRepo)._0 }}
              "{{ $chartHost }}": {
-               "auth": {{ printf "%s:%s" (secret "jx-boot-job-env-vars" "JX_REPOSITORY_USERNAME") (secret "jx-boot-job-env-vars" "JX_REPOSITORY_PASSWORD") | b64enc | quote }}
+               "auth": {{ printf "%s:%s" (secret "jx-git-operator.jx-boot-job-env-vars" "JX_REPOSITORY_USERNAME") (secret "jx-git-operator.jx-boot-job-env-vars" "JX_REPOSITORY_PASSWORD") | b64enc | quote }}
              }
           {{- end }}
           {{- end }}


### PR DESCRIPTION
### Changes
* Find ACR username and password from the `jx-git-operator` namespace for auth

### Context

The referenced secret needs to be namespaced, otherwise the template ignores it
